### PR TITLE
Handle ResetFormAction fields the right way.

### DIFF
--- a/templates/BootstrapFormAction.ss
+++ b/templates/BootstrapFormAction.ss
@@ -1,3 +1,3 @@
-<button type="submit" class="btn <% if ButtonStyle %>btn-{$ButtonStyle}<% end_if %> <% if ButtonSize %>btn-{$ButtonSize}<% end_if %>">
+<button type="<% if Type='resetformaction' %>reset<% else %>submit<% end_if %>" class="btn <% if ButtonStyle %>btn-{$ButtonStyle}<% end_if %> <% if ButtonSize %>btn-{$ButtonSize}<% end_if %>">
 	<% if ButtonContent %>$ButtonContent<% else %>$Title<% end_if %>
 </button>


### PR DESCRIPTION
Added a new "if"-condition in the BootstrapFormAction template to handle Actions of the ResetFormAction class.  Without this little piece of code, every Action is treated as a "submit"-Action wich is not allways what you want and changes also the default behaviour of the button.
