### PR TITLE
BUGFIX: SimpleHtmlEditorFiled breaks JavaScript (Issue #4)

### DIFF
--- a/javascript/bootstrap_forms.js
+++ b/javascript/bootstrap_forms.js
@@ -11,9 +11,9 @@ $(function() {
 		      theme_advanced_buttons2: "",
 		      theme_advanced_buttons3: "",
 		      theme_advanced_blockformats: $t.attr('data-blockformats'),
-		      content_css: ($('base')).attr('href') + $t.attr('data-css')
+		      content_css: ($t.attr('data-css') ? ($('base')).attr('href') + $t.attr('data-css') : null)
 		    });
-		})
+		});
 	}
 
 	


### PR DESCRIPTION
Added a check to see if data-css attribute is set. If not, content_css is set to 'NULL'

This commit solves issue #4
