### PR TITLE
Enable adding classes to input and label directly (also needs work in display-logic module)

### DIFF
--- a/code/BootstrapFormField.php
+++ b/code/BootstrapFormField.php
@@ -20,10 +20,16 @@ class BootstrapFormField extends DataExtension {
 		"form-group"
 	);
 
+	protected $labelClasses = array(
+	);
+
+	protected $inputClasses = array(
+	);
+
 
 	/**
 	 * Adds a HTML5 placeholder attribute to the form field
-	 * 
+	 *
 	 * @param $text the placeholder text to add
 	 * @return BootstrapFormField
 	 */
@@ -31,7 +37,7 @@ class BootstrapFormField extends DataExtension {
 		return $this->owner->setAttribute("placeholder",$text);
 	}
 
-	
+
 	/**
 	 * Adds a block of help text to the form field. (HTML safe).
 	 * By default, this text appears below a field and its label.
@@ -89,13 +95,61 @@ class BootstrapFormField extends DataExtension {
 	}
 
 	/**
-	 * Allows adding custom classes to the holder 
-	 * 
+	 * Allows adding custom classes to the input
+	 *
 	 * @param string $class the class
-	 * 
+	 *
 	 * @return BootstrapFormField
 	 */
-	public function addHolderClass($class) {		
+	public function addInputClass($class) {
+		$this->inputClasses[] = $class;
+		return $this->owner;
+	}
+
+	/**
+	 * returns the input classes to be used in templates
+	 * also triggers checking for error messages
+	 *
+	 * @return string of classes
+	 */
+	public function InputClasses() {
+		$this->loadErrorMessage();
+
+		return implode(" ",$this->inputClasses);
+	}
+
+		/**
+	 * Allows adding custom classes to the label
+	 *
+	 * @param string $class the class
+	 *
+	 * @return BootstrapFormField
+	 */
+	public function addLabelClass($class) {
+		$this->labelClasses[] = $class;
+		return $this->owner;
+	}
+
+	/**
+	 * returns the label classes to be used in templates
+	 * also triggers checking for error messages
+	 *
+	 * @return string of classes
+	 */
+	public function LabelClasses() {
+		$this->loadErrorMessage();
+
+		return implode(" ",$this->labelClasses);
+	}
+
+	/**
+	 * Allows adding custom classes to the holder
+	 *
+	 * @param string $class the class
+	 *
+	 * @return BootstrapFormField
+	 */
+	public function addHolderClass($class) {
 		$this->holderClasses[] = $class;
 		return $this->owner;
 	}
@@ -103,7 +157,7 @@ class BootstrapFormField extends DataExtension {
 	/**
 	 * returns the holder classes to be used in templates
 	 * also triggers checking for error messages
-	 * 
+	 *
 	 * @return string of classes
 	 */
 	public function HolderClasses() {
@@ -127,7 +181,7 @@ class BootstrapFormField extends DataExtension {
 	/**
 	 * checks for error messages in owner form field
 	 * adds error class to holder and loads error message as helptext
-	 * 
+	 *
 	 * @todo allow setting error message as inline
 	 */
 	private function loadErrorMessage() {
@@ -136,5 +190,5 @@ class BootstrapFormField extends DataExtension {
 			$this->addHelpText($this->owner->message);
 		}
 	}
-	
+
 }

--- a/templates/BootstrapCheckboxField_holder.ss
+++ b/templates/BootstrapCheckboxField_holder.ss
@@ -1,13 +1,13 @@
 <div id="$Name" class="checkbox $HolderClasses" $HolderAttributes>
-    <label>
-        <input $AttributesHTML>
+    <label class="$labelClasses">
         $Title
+        <input $AttributesHTML class="$inputClasses">
     </label>
     <% if $HelpText %>
     <p class="help-block">$HelpText</p>
     <% end_if %>
     <% if $InlineHelpText %>
     <span class="help-inline">$InlineHelpText</span>
-    <% end_if %>    
+    <% end_if %>
 </div>
 


### PR DESCRIPTION
Add the ability to add the bootstrap grid fields to the label and input directly

also see https://github.com/unclecheese/silverstripe-display-logic/pull/30

as per this from http://getbootstrap.com/css/#forms-horizontal

```
<form class="form-horizontal" role="form">
  <div class="form-group">
    <label for="inputEmail3" class="col-sm-2 control-label">Email</label>
    <div class="col-sm-10">
      <input type="email" class="form-control" id="inputEmail3" placeholder="Email">
    </div>
  </div>
  <div class="form-group">
    <label for="inputPassword3" class="col-sm-2 control-label">Password</label>
    <div class="col-sm-10">
      <input type="password" class="form-control" id="inputPassword3" placeholder="Password">
    </div>
  </div>
  <div class="form-group">
    <div class="col-sm-offset-2 col-sm-10">
      <div class="checkbox">
        <label>
          <input type="checkbox"> Remember me
        </label>
      </div>
    </div>
  </div>
  <div class="form-group">
    <div class="col-sm-offset-2 col-sm-10">
      <button type="submit" class="btn btn-default">Sign in</button>
    </div>
  </div>
</form>
```
