### PR TITLE
Add LabelClasses in FieldHolder and TextField_holder templates

### DIFF
--- a/templates/BootstrapFieldHolder.ss
+++ b/templates/BootstrapFieldHolder.ss
@@ -1,5 +1,5 @@
 <div id="$Name" class="$HolderClasses" $HolderAttributes>
-    <label for="$ID">$Title</label>
+    <label for="$ID" class="$LabelClasses">$Title</label>
     $Field        
     <% if $HelpText %>
     <p class="help-block">$HelpText</p>

--- a/templates/BootstrapTextField_holder.ss
+++ b/templates/BootstrapTextField_holder.ss
@@ -1,5 +1,5 @@
 <div id="$Name" class="<% if $AppendedText || $PrependedText %>input-group<% end_if %> $HolderClasses" $HolderAttributes>
-    <label for="$ID">$Title</label>    
+    <label for="$ID" class="$LabelClasses">$Title</label>
     <% if $PrependedText %>
         <span class="input-group-addon">$PrependedText</span>
     <% end_if %>


### PR DESCRIPTION
It allows to add an extra classes to a label, and it helps to the accessibility. If you want to hide the label, but keep it for the screen-reader, you can just add "sr-only"